### PR TITLE
Point to new landlab-rest server at csdms.io

### DIFF
--- a/app/assets/index.html
+++ b/app/assets/index.html
@@ -3,7 +3,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
   <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height, target-densitydpi=device-dpi" />
-  <title>Lablab Sketchbook</title>
+  <title>Landlab Sketchbook</title>
   <link rel="stylesheet" type="text/css" href="app.css">
 </head>
 <body>

--- a/app/components/app.jsx
+++ b/app/components/app.jsx
@@ -6,7 +6,7 @@ import Inputs from './inputs';
 
 import app from '../theme/app.scss';
 
-const apiBase = 'https://sketchbook.openearthscape.org:8000';
+const apiBase = 'https://csdms.io:2083';
 
 class App extends React.Component {
   constructor() {


### PR DESCRIPTION
This PR updates the sketchbook web app to look for the landlab-rest server at `csdms.io:2083` instead of `sketchbook.openearthscape.org:8000`. I also fixed a minor typo in the app title.